### PR TITLE
Fixes memory leak in API server

### DIFF
--- a/src/api.rs
+++ b/src/api.rs
@@ -20,12 +20,12 @@ async fn status_handler() -> StatusCode {
 }
 
 /// Returns the latest Prometheus-format metrics snapshot.
-async fn metrics_handler(State(snapshot): State<&'static ArcSwap<String>>) -> String {
+async fn metrics_handler(State(snapshot): State<Arc<ArcSwap<String>>>) -> String {
     snapshot.load().as_ref().clone()
 }
 
 /// Builds the Axum router with shared application state.
-fn build_router(snapshot: &'static ArcSwap<String>) -> Router {
+fn build_router(snapshot: Arc<ArcSwap<String>>) -> Router {
     Router::new()
         .route("/", get(status_handler))
         .route("/metrics", get(metrics_handler))
@@ -47,11 +47,6 @@ pub async fn serve(
     port: u16,
     snapshot: Arc<ArcSwap<String>>,
 ) -> Result<(), Box<dyn std::error::Error>> {
-    let snapshot: &'static ArcSwap<String> = {
-        let leaked: &'static Arc<ArcSwap<String>> = Box::leak(Box::new(snapshot));
-        leaked.as_ref()
-    };
-
     let router = build_router(snapshot);
     let addr = format!("{host}:{port}");
     let listener = TcpListener::bind(&addr).await?;

--- a/src/profilers/default.rs
+++ b/src/profilers/default.rs
@@ -28,7 +28,7 @@ impl DefaultProfiler {
 impl Profiler for DefaultProfiler {
     /// Returns high level status metrics.
     fn collect_metrics(&mut self, processes: &[HpcProcess]) -> Result<Vec<Metric>, Box<dyn Error>> {
-        let epoch_time = SystemTime::now().duration_since(SystemTime::UNIX_EPOCH);
+        let epoch_time = SystemTime::now().duration_since(SystemTime::UNIX_EPOCH)?;
         let unique_jobs: HashSet<&str> = processes.iter().map(|p| p.jobid.as_str()).collect();
 
         Ok(vec![
@@ -40,7 +40,7 @@ impl Profiler for DefaultProfiler {
             Metric {
                 name: "kys_scrape_time",
                 labels: vec![("hostname", HOSTNAME.clone())],
-                value: epoch_time?.as_secs_f64(),
+                value: epoch_time.as_secs_f64(),
             },
         ])
     }


### PR DESCRIPTION
The HTTP server was leaking memory on startup by using Box::leak to satisfy Axum's lifetime requirements for shared state. Since Axum supports Arc directly, the leaked pointer is replaced with an Arc, which is cheaply cloned per request instead. No behavior changes; call sites in main.rs are unaffected.

Closes #15 