### PR TITLE
Rename metrics prefix from kys to hpcexp

### DIFF
--- a/src/profilers/default.rs
+++ b/src/profilers/default.rs
@@ -33,12 +33,12 @@ impl Profiler for DefaultProfiler {
 
         Ok(vec![
             Metric {
-                name: "kys_running_jobs",
+                name: "hpcexp_running_jobs",
                 labels: vec![("hostname", HOSTNAME.clone())],
                 value: unique_jobs.len() as f64,
             },
             Metric {
-                name: "kys_scrape_time",
+                name: "hpcexp_scrape_time",
                 labels: vec![("hostname", HOSTNAME.clone())],
                 value: epoch_time.as_secs_f64(),
             },

--- a/src/profilers/nvidia.rs
+++ b/src/profilers/nvidia.rs
@@ -114,12 +114,12 @@ impl Profiler for NvidiaProfiler {
 
             if let Ok(util) = device.utilization_rates() {
                 metrics.push(Metric {
-                    name: "kys_gpu_utilization_percent",
+                    name: "hpcexp_gpu_utilization_percent",
                     labels: labels.clone(),
                     value: util.gpu as f64,
                 });
                 metrics.push(Metric {
-                    name: "kys_gpu_memory_utilization_percent",
+                    name: "hpcexp_gpu_memory_utilization_percent",
                     labels: labels.clone(),
                     value: util.memory as f64,
                 });
@@ -127,17 +127,17 @@ impl Profiler for NvidiaProfiler {
 
             if let Ok(mem) = device.memory_info() {
                 metrics.push(Metric {
-                    name: "kys_gpu_memory_total_bytes",
+                    name: "hpcexp_gpu_memory_total_bytes",
                     labels: labels.clone(),
                     value: mem.total as f64,
                 });
                 metrics.push(Metric {
-                    name: "kys_gpu_memory_used_bytes",
+                    name: "hpcexp_gpu_memory_used_bytes",
                     labels: labels.clone(),
                     value: mem.used as f64,
                 });
                 metrics.push(Metric {
-                    name: "kys_gpu_memory_free_bytes",
+                    name: "hpcexp_gpu_memory_free_bytes",
                     labels: labels.clone(),
                     value: mem.free as f64,
                 });
@@ -145,7 +145,7 @@ impl Profiler for NvidiaProfiler {
 
             if let Ok(temp) = device.temperature(TemperatureSensor::Gpu) {
                 metrics.push(Metric {
-                    name: "kys_gpu_temperature_celsius",
+                    name: "hpcexp_gpu_temperature_celsius",
                     labels: labels.clone(),
                     value: temp as f64,
                 });
@@ -153,7 +153,7 @@ impl Profiler for NvidiaProfiler {
 
             if let Ok(power) = device.power_usage() {
                 metrics.push(Metric {
-                    name: "kys_gpu_power_usage_watts",
+                    name: "hpcexp_gpu_power_usage_watts",
                     labels: labels.clone(),
                     value: power as f64 / 1000.0,
                 });
@@ -161,7 +161,7 @@ impl Profiler for NvidiaProfiler {
 
             if let Ok(clock) = device.clock_info(Clock::Graphics) {
                 metrics.push(Metric {
-                    name: "kys_gpu_clock_graphics_mhz",
+                    name: "hpcexp_gpu_clock_graphics_mhz",
                     labels: labels.clone(),
                     value: clock as f64,
                 });
@@ -169,7 +169,7 @@ impl Profiler for NvidiaProfiler {
 
             if let Ok(clock) = device.clock_info(Clock::Memory) {
                 metrics.push(Metric {
-                    name: "kys_gpu_clock_memory_mhz",
+                    name: "hpcexp_gpu_clock_memory_mhz",
                     labels: labels.clone(),
                     value: clock as f64,
                 });
@@ -177,7 +177,7 @@ impl Profiler for NvidiaProfiler {
 
             if let Ok(fan) = device.fan_speed(0) {
                 metrics.push(Metric {
-                    name: "kys_gpu_fan_speed_percent",
+                    name: "hpcexp_gpu_fan_speed_percent",
                     labels: labels.clone(),
                     value: fan as f64,
                 });
@@ -216,13 +216,13 @@ impl Profiler for NvidiaProfiler {
             let labels = Self::job_labels(jobid, stepid, gpu_uuid);
 
             metrics.push(Metric {
-                name: "kys_gpu_job_memory_used_bytes",
+                name: "hpcexp_gpu_job_memory_used_bytes",
                 labels: labels.clone(),
                 value: snap.memory_bytes as f64,
             });
 
             metrics.push(Metric {
-                name: "kys_gpu_job_process_count",
+                name: "hpcexp_gpu_job_process_count",
                 labels,
                 value: snap.process_count as f64,
             });

--- a/src/profilers/system.rs
+++ b/src/profilers/system.rs
@@ -79,27 +79,27 @@ impl SystemProfiler {
 
         let mut metrics = vec![
             Metric {
-                name: "kys_sys_cpu_usage_percent",
+                name: "hpcexp_sys_cpu_usage_percent",
                 labels: Self::node_labels(),
                 value: total_cpu,
             },
             Metric {
-                name: "kys_sys_cpu_count",
+                name: "hpcexp_sys_cpu_count",
                 labels: Self::node_labels(),
                 value: cpu_count,
             },
             Metric {
-                name: "kys_sys_load_avg_1m",
+                name: "hpcexp_sys_load_avg_1m",
                 labels: Self::node_labels(),
                 value: load.one,
             },
             Metric {
-                name: "kys_sys_load_avg_5m",
+                name: "hpcexp_sys_load_avg_5m",
                 labels: Self::node_labels(),
                 value: load.five,
             },
             Metric {
-                name: "kys_sys_load_avg_15m",
+                name: "hpcexp_sys_load_avg_15m",
                 labels: Self::node_labels(),
                 value: load.fifteen,
             },
@@ -108,7 +108,7 @@ impl SystemProfiler {
         // Per-core utilization
         for (i, cpu) in cpus.iter().enumerate() {
             metrics.push(Metric {
-                name: "kys_sys_cpu_core_usage_percent",
+                name: "hpcexp_sys_cpu_core_usage_percent",
                 labels: Self::core_labels(i),
                 value: cpu.cpu_usage() as f64,
             });
@@ -123,32 +123,32 @@ impl SystemProfiler {
 
         vec![
             Metric {
-                name: "kys_sys_memory_total_bytes",
+                name: "hpcexp_sys_memory_total_bytes",
                 labels: Self::node_labels(),
                 value: self.sys.total_memory() as f64,
             },
             Metric {
-                name: "kys_sys_memory_used_bytes",
+                name: "hpcexp_sys_memory_used_bytes",
                 labels: Self::node_labels(),
                 value: self.sys.used_memory() as f64,
             },
             Metric {
-                name: "kys_sys_memory_available_bytes",
+                name: "hpcexp_sys_memory_available_bytes",
                 labels: Self::node_labels(),
                 value: self.sys.available_memory() as f64,
             },
             Metric {
-                name: "kys_sys_swap_total_bytes",
+                name: "hpcexp_sys_swap_total_bytes",
                 labels: Self::node_labels(),
                 value: self.sys.total_swap() as f64,
             },
             Metric {
-                name: "kys_sys_swap_used_bytes",
+                name: "hpcexp_sys_swap_used_bytes",
                 labels: Self::node_labels(),
                 value: self.sys.used_swap() as f64,
             },
             Metric {
-                name: "kys_sys_swap_free_bytes",
+                name: "hpcexp_sys_swap_free_bytes",
                 labels: Self::node_labels(),
                 value: self.sys.free_swap() as f64,
             },
@@ -219,37 +219,37 @@ impl SystemProfiler {
             let labels = Self::job_labels(jobid, stepid);
 
             metrics.push(Metric {
-                name: "kys_sys_job_cpu_usage_percent",
+                name: "hpcexp_sys_job_cpu_usage_percent",
                 labels: labels.clone(),
                 value: snap.cpu_usage as f64,
             });
 
             metrics.push(Metric {
-                name: "kys_sys_job_memory_used_bytes",
+                name: "hpcexp_sys_job_memory_used_bytes",
                 labels: labels.clone(),
                 value: snap.memory_bytes as f64,
             });
 
             metrics.push(Metric {
-                name: "kys_sys_job_virtual_memory_bytes",
+                name: "hpcexp_sys_job_virtual_memory_bytes",
                 labels: labels.clone(),
                 value: snap.virtual_memory_bytes as f64,
             });
 
             metrics.push(Metric {
-                name: "kys_sys_job_io_read_bytes",
+                name: "hpcexp_sys_job_io_read_bytes",
                 labels: labels.clone(),
                 value: snap.io_read_bytes as f64,
             });
 
             metrics.push(Metric {
-                name: "kys_sys_job_io_write_bytes",
+                name: "hpcexp_sys_job_io_write_bytes",
                 labels: labels.clone(),
                 value: snap.io_written_bytes as f64,
             });
 
             metrics.push(Metric {
-                name: "kys_sys_job_process_count",
+                name: "hpcexp_sys_job_process_count",
                 labels,
                 value: snap.process_count as f64,
             });


### PR DESCRIPTION
Renames metrics to use the common `hpcexp_` prefix.

Closes #14 