### PR TITLE
Fixes drift in collection interval

### DIFF
--- a/src/collector.rs
+++ b/src/collector.rs
@@ -6,7 +6,7 @@
 
 use std::sync::Arc;
 use std::thread;
-use std::time::Duration;
+use std::time::{Duration, Instant};
 
 use arc_swap::ArcSwap;
 use bytes::Bytes;
@@ -40,7 +40,10 @@ pub fn run(
         let mut buf = bytes::BytesMut::new();
 
         loop {
-            // Collect hardware metrics from each profiler
+            // Determine when the next collection is supposed to start
+            let deadline = Instant::now() + interval;
+
+            // Execute the current metrics collection
             let result = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
                 collect_into_buffer(&mut profilers, &*scheduler, &mut buf);
             }));
@@ -62,7 +65,15 @@ pub fn run(
                 }
             }
 
-            thread::sleep(interval);
+            // Sleep until the next metrics collection is scheduled to start
+            // Begin immediately if the previous collection overran the deadline
+            match deadline.checked_duration_since(Instant::now()) {
+                Some(remaining) => thread::sleep(remaining),
+                None => warn!(
+                    "collection pass exceeded the configured interval ({interval:?}); \
+                     consider increasing --interval"
+                ),
+            }
         }
     });
 }


### PR DESCRIPTION
Fixes collection interval drift caused by `thread::sleep(interval)` running after collection rather than accounting for it. A deadline is now set at the top of each collection loop iteration and the thread sleeps only the remaining time. If a pass overshoots the deadline, the sleep is skipped and a warning is logged suggesting the operator widen `--interval`. No catch-up logic is introduced — a late pass skips one sleep rather than firing back-to-back.

Closes #13 